### PR TITLE
feature: add textfield component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import {Button} from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 export default function Home() {
   return (
     <>
       <div>Hello World!</div>
       <Button> Click me</Button>
+      <Input ></Input>
     </>
   );
 }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,80 @@
+
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { InputProps } from "@/types/components/input";
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      label,
+      helperText,
+      error,
+      iconLeft,
+      iconRight,
+      className,
+      id,
+      type = "text",
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = React.useId();
+    const inputId = id ?? generatedId;
+
+
+    return (
+      <div className="space-y-1">
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="text-sm font-medium leading-none"
+          >
+            {label}
+          </label>
+        )}
+
+        <div className="relative">
+          {iconLeft && (
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+              {iconLeft}
+            </span>
+          )}
+
+          <input
+            id={inputId}
+            ref={ref}
+            type={type}
+            data-slot="input"
+            aria-invalid={!!error}
+            className={cn(
+            "appearance-none block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
+            iconLeft && "pl-10",
+            iconRight && "pr-10",
+            error && "border-red-500 focus:border-red-500 focus:ring-red-500",
+            className
+            )}
+            {...props}
+          />
+
+          {iconRight && (
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+              {iconRight}
+            </span>
+          )}
+        </div>
+
+        {error ? (
+          <p className="text-sm text-red-500">{error}</p>
+        ) : helperText ? (
+          <p className="text-sm text-muted-foreground">{helperText}</p>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+Input.displayName = "Input";
+
+export { Input };
+

--- a/src/types/components/input.ts
+++ b/src/types/components/input.ts
@@ -1,0 +1,7 @@
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  iconLeft?: React.ReactNode;
+  iconRight?: React.ReactNode;
+  helperText?: string;
+}


### PR DESCRIPTION
Added a TextInput (Input) component with:

Optional label, helperText, error, iconLeft, iconRight

Built on top of shadcn/ui base

Added Type safety via custom InputProps in @/types/components/input.ts

